### PR TITLE
Remove htmlspecialchars since that happens automatically on output

### DIFF
--- a/ProcessMaker/Http/Middleware/SanitizeInput.php
+++ b/ProcessMaker/Http/Middleware/SanitizeInput.php
@@ -53,10 +53,6 @@ class SanitizeInput extends TransformsRequest
             // Remove most injectable code
             $value = strip_tags($value);
             
-            // Run this for double safety, but we do allow quotes, for example
-            // to allow for users who have names such as Conan O'Brien
-            $value = htmlspecialchars($value, ENT_NOQUOTES, null, true); 
-            
             // Return the sanitized string
             return $value;
         }


### PR DESCRIPTION
Fixes #1648 

It was double encoding

@PMQABen need to hammer this again with injection, etc. 