### PR TITLE
Can't hide File Upload / Download

### DIFF
--- a/resources/js/processes/screen-builder/components/file-download.vue
+++ b/resources/js/processes/screen-builder/components/file-download.vue
@@ -1,10 +1,15 @@
 <template>
     <div>
-        <div v-for="file in files.data" v-if="loaded">
-            <b-btn class="mb-2" variant="primary" @click="onClick(file)">
-                <i class="fas fa-file-download"></i> {{$t('Download')}}
-            </b-btn>
-            {{file.file_name}}
+        <template  v-if="loaded && files.data && files.data.length !== 0">
+            <div v-for="file in files.data">
+                <b-btn class="mb-2" variant="primary" @click="onClick(file)">
+                    <i class="fas fa-file-download"></i> {{$t('Download')}}
+                </b-btn>
+                {{file.file_name}}
+            </div>
+        </template>
+        <div v-else>
+            {{$t('No files available for download')}}
         </div>
     </div>
 </template>


### PR DESCRIPTION
Resolves #1591 

Add message by default when the component download file has no items to display.

![image](https://user-images.githubusercontent.com/1747025/56226635-a0e4ca00-6041-11e9-9c33-0b2225513c24.png)


![image](https://user-images.githubusercontent.com/1747025/56226561-7bf05700-6041-11e9-948e-1d8527f4cc37.png)

![image](https://user-images.githubusercontent.com/1747025/56226572-7eeb4780-6041-11e9-81be-b5a7c5f745e8.png)
