### PR TITLE
Completed Tasks Cannot be Reassigned

### DIFF
--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -92,9 +92,11 @@
                                     <div>
                                         <br>
                                         <span>
+                                @if ($task->advanceStatus === 'open')
                                 <button class="btn btn-outline-secondary btn-block" @click="show">
                                     <i class="fas fa-user-friends"></i> {{__('Reassign')}}
                                 </button>
+                                @endif
                                 <b-modal v-model="showReassignment" size="md" centered title="{{__('Reassign to')}}" @hide="cancelReassign"
                                          v-cloak>
                                     <div class="form-group">


### PR DESCRIPTION
closes #1719 

the reassign button is only shown when a task is open
![Screen Shot 2019-04-22 at 3 03 00 PM](https://user-images.githubusercontent.com/29641725/56535681-27514e00-6511-11e9-9f67-a95f243a1cb2.png)
![Screen Shot 2019-04-22 at 3 13 38 PM](https://user-images.githubusercontent.com/29641725/56535709-3932f100-6511-11e9-9a0e-c4b7dfe4c8a3.png)

