### PR TITLE
Request Fails in Error

### DIFF
--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -395,7 +395,7 @@
               "ACTIVE": "{{__('Created')}}",
               "COMPLETED": "{{__('Completed')}}",
               "CANCELED": "{{__('Canceled')}}",
-              "ERROR": "{{__('Canceled')}}",
+              "ERROR": "{{__('Error')}}",
             };
 
             return status[this.request.status.toUpperCase()];


### PR DESCRIPTION
closes #1686 

to test, follow the steps in 1686 
When a request fails or is in an error state the sidebar will now read as "error".