### PR TITLE
Modal Link Not Working

### DIFF
--- a/resources/js/components/requests/modal.vue
+++ b/resources/js/components/requests/modal.vue
@@ -36,7 +36,7 @@
             <div class="no-requests" v-if="!Object.keys(processes).length && !loading">
                 <h4>{{$t('You don\'t have any Processes.')}}</h4>
                 <span v-if="permission.includes('create-processes')">
-                    <a href="/processes">{{$t('Please visit the Processes page')}}</a>
+                    <span @click="redirect" class="text-primary">{{$t('Please visit the Processes page')}}</span>
                     {{$t('and click on +Process to get started.')}}
                 </span>
                 <span v-else>{{$t('Please contact your administrator to get started.')}}</span>
@@ -85,6 +85,9 @@
       }, 250)
     },
     methods: {
+      redirect() {
+        window.location = "/processes" 
+      },
       showRequestModal() {
         if (!this.loaded) {
           // Perform initial load of requests from backend


### PR DESCRIPTION
closes #1708 

added a new onClick event in the request modal, the modal was overriding the href. 
![Screen Shot 2019-04-23 at 10 55 55 AM](https://user-images.githubusercontent.com/29641725/56604250-62f22380-65b6-11e9-9d6a-fa0f261542e1.png)
