### PR TITLE
Include description when saving script

### DIFF
--- a/resources/js/processes/scripts/components/ScriptEditor.vue
+++ b/resources/js/processes/scripts/components/ScriptEditor.vue
@@ -136,6 +136,7 @@
                     .put("scripts/" + this.script.id, {
                         code: this.code,
                         title: this.script.title,
+                        description: this.script.description,
                         language: this.script.language,
                         run_as_user_id: this.script.run_as_user_id
                     })


### PR DESCRIPTION
## Changes
- Includes description when saving scripts in script builder to fix issue where scripts could not be saved from script builder

Closes #1760.