### PR TITLE
open modal when there is no data

### DIFF
--- a/resources/js/processes/categories/components/CategoriesListing.vue
+++ b/resources/js/processes/categories/components/CategoriesListing.vue
@@ -122,8 +122,12 @@ export default {
             "&include=processesCount"
         )
         .then(response => {
-          this.data = this.transform(response.data);
-          this.loading = false;
+          if(this.data.length === 0){
+              $('#createProcessCategory').modal('show')
+            }else {
+              this.data = this.transform(response.data);
+              this.loading = false;
+            }
         });
     },
     transform(data) {


### PR DESCRIPTION
closes #1709 
To test:

re-seed database so that you have no processes available,
go to process listing, add a new process use category modal to be redirected to the categories page and see modal auto open