### PR TITLE
add text-break until vuetable2 releases a tr component to style further

### DIFF
--- a/resources/js/components/common/mixins/datatable.js
+++ b/resources/js/components/common/mixins/datatable.js
@@ -99,7 +99,7 @@ export default {
             // Cancel token which should be stored from axios if you want to cancel the current in progress request
             cancelToken: null,
             css: {
-                tableClass: "table table-hover table-responsive",
+                tableClass: "table table-hover table-responsive text-break",
                 loadingClass: "loading",
                 detailRowClass: "vuetable-detail-row",
                 handleIcon: "grey sidebar icon",


### PR DESCRIPTION
closes #1687 

this doesn't 100% satisfy the requirements but we will have to wait until vuetable2 releases their update for styling the TR directly. But the table will not break any-longer in the event of a user having super long names or descriptions 

https://www.vuetable.com/guide/css-styling.html#generated-html-table
![Screen Shot 2019-05-06 at 11 50 34 AM](https://user-images.githubusercontent.com/29641725/57247844-bbcdad00-6ff5-11e9-8069-736c13500a2b.png)
