### PR TITLE
Fix issue with global error handler

### DIFF
--- a/resources/js/app-layout.js
+++ b/resources/js/app-layout.js
@@ -128,10 +128,10 @@ window.ProcessMaker.apiClient.interceptors.response.use((response) => {
 // Display any uncaught promise rejections from axios in the Process Maker alert box
 window.addEventListener('unhandledrejection', function (event) {
     let error = event.reason;
-    if (error.config._defaultErrorShown) {
+    if (error.config && error.config._defaultErrorShown) {
         // Already handeled
         event.preventDefault(); // stops the unhandled rejection error
-    } else if (error.response.data && error.response.data.message) {
+    } else if (error.response && error.response.data && error.response.data.message) {
         window.ProcessMaker.alert(error.response.data.message, "danger");
     } else if (error.message) {
         window.ProcessMaker.alert(error.message, "danger");


### PR DESCRIPTION
## Changes
- Fixes an issue where we were not properly checking for a parent property's existence before checking for a child property, causing extraneous console errors to appear

Fixes #1757.