### PR TITLE
Notifications Tweaks

### DIFF
--- a/resources/js/components/requests/notifications.vue
+++ b/resources/js/components/requests/notifications.vue
@@ -22,10 +22,12 @@
           <div class="d-flex align-items-end flex-column float-right">
             <small class="float-right muted" v-b-tooltip.hover :title="moment(task.created_at).format()">{{ moment(task.created_at).fromNow() }}</small>
             <div
-              class="badge badge-pill badge-info float-right mt-1"
+              class="text-info float-right mt-1"
               style="cursor:pointer"
               @click="remove(task)"
-            >{{$t('Dismiss')}}</div>
+              v-b-tooltip.hover
+              :title="$t('Dismiss Alert')"
+            ><i class="fa fa-trash"></i></div>
           </div>
 
           <h3>

--- a/resources/js/components/requests/notifications.vue
+++ b/resources/js/components/requests/notifications.vue
@@ -20,7 +20,7 @@
         </li>
         <li v-for="(task, index) in messages" v-if="index <= 5">
           <div class="d-flex align-items-end flex-column float-right">
-            <small class="float-right muted">{{ moment(task.dateTime).format() }}</small>
+            <small class="float-right muted" v-b-tooltip.hover :title="moment(task.created_at).format()">{{ moment(task.created_at).fromNow() }}</small>
             <div
               class="badge badge-pill badge-info float-right mt-1"
               style="cursor:pointer"


### PR DESCRIPTION
## Changes
- Relative time displays for each notification
- Hovering over the relative time reveals the absolute time as a tooltip
- Dismiss button for each notification is now a trash can icon with a tooltip

## Screenshots

_Notification popover_
<img width="295" alt="Screen Shot 2019-05-06 at 4 48 51 PM" src="https://user-images.githubusercontent.com/867714/57262047-58587500-701f-11e9-81ae-dee55f414222.png">

_Notification popover with absolute time tooltip_
<img width="313" alt="Screen Shot 2019-05-06 at 4 49 09 PM" src="https://user-images.githubusercontent.com/867714/57262053-5a223880-701f-11e9-87c6-7ec18b5f319d.png">

_Notification popover with dismissal tooltip_
<img width="357" alt="Screen Shot 2019-05-06 at 4 49 21 PM" src="https://user-images.githubusercontent.com/867714/57262056-5b536580-701f-11e9-87a4-19158e51a9ce.png">


Closes #1720.