### PR TITLE
Edit User Form Defaults

### DIFF
--- a/ProcessMaker/Http/Controllers/Api/UserController.php
+++ b/ProcessMaker/Http/Controllers/Api/UserController.php
@@ -129,6 +129,15 @@ class UserController extends Controller
         if (isset($fields['password'])) {
             $fields['password'] = Hash::make($fields['password']);
         }
+
+        if (!isset($fields['timezone'])) {
+            $fields['timezone'] = env('APP_TIMEZONE');
+        }
+
+        if (!isset($fields['datetime_format'])) {
+            $fields['datetime_format'] = env('DATE_FORMAT');
+        }
+
         $user->fill($fields);
         $user->saveOrFail();
         return new UserResource($user->refresh());

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -77,8 +77,8 @@ class UsersTest extends TestCase
 
     public function testDefaultValuesOfUser()
     {
-        putenv('APP_TIMEZONE=Test/test');
-        putenv('DATE_FORMAT=testFormat');
+        putenv('APP_TIMEZONE=Africa/Niamey');
+        putenv('DATE_FORMAT=d/M/Y');
 
         // Create a user without setting fields that have default
         $faker = Faker::create();

--- a/tests/Feature/Api/UsersTest.php
+++ b/tests/Feature/Api/UsersTest.php
@@ -75,6 +75,56 @@ class UsersTest extends TestCase
         $response->assertStatus(201);
     }
 
+    public function testDefaultValuesOfUser()
+    {
+        putenv('APP_TIMEZONE=Test/test');
+        putenv('DATE_FORMAT=testFormat');
+
+        // Create a user without setting fields that have default
+        $faker = Faker::create();
+        $url = self::API_TEST_URL;
+        $response = $this->apiCall('POST', $url, [
+            'username' => 'username1',
+            'firstname' => 'name',
+            'lastname' => 'name',
+            'email' => $faker->email,
+            'status' => $faker->randomElement(['ACTIVE', 'INACTIVE']),
+            'password' => $faker->sentence(10)
+        ]);
+
+        $response->assertStatus(201);
+
+        // Validate that the created user has the correct default values
+        $createdUser = $response->json();
+        $this->assertNotNull($createdUser['timezone'], env('APP_TIMEZONE'));
+        $this->assertNotNull($createdUser['datetime_format'], env('DATE_FORMAT'));
+
+
+        // Create a user setting fields that have default
+        $timeZone = 'Test/Test';
+        $dateFormat = 'testFormat';
+        $faker = Faker::create();
+        $url = self::API_TEST_URL;
+        $response = $this->apiCall('POST', $url, [
+            'username' => 'username2',
+            'firstname' => 'name',
+            'lastname' => 'name',
+            'email' => $faker->email,
+            'status' => $faker->randomElement(['ACTIVE', 'INACTIVE']),
+            'password' => $faker->sentence(10),
+            'timezone' => $timeZone,
+            'datetime_format' => $dateFormat
+        ]);
+
+        $response->assertStatus(201);
+
+        // Validate that the created user has the correct values
+        $createdUser = $response->json();
+        $this->assertEquals($createdUser['timezone'], $timeZone);
+        $this->assertEquals($createdUser['datetime_format'], $dateFormat);
+
+    }
+
     /**
      * Can not create a user with an existing username
      */


### PR DESCRIPTION
Resolves #1642 

- When creating a new user, if no timezone or date format is passed, the environment variable are used as default. Those values are displayed when editing a user for the first time.
- Test to verify the functionality were added