### PR TITLE
Revert "Fix FormText import"

### DIFF
--- a/resources/js/processes/modeler/initialLoad.js
+++ b/resources/js/processes/modeler/initialLoad.js
@@ -58,7 +58,7 @@ let nodeTypes = [
     serviceTask,
     textAnnotation,
     eventBasedGateway,
-    intermediateMessageCatchEvent
+    intermediateMessageCatchEvent,
 ]
 
 ProcessMaker.nodeTypes.push(startEvent);
@@ -67,7 +67,7 @@ ProcessMaker.nodeTypes.push(...nodeTypes);
 // Implement user list and group list for intermediate catch event
 // eslint-disable-next-line func-names
 (function () {
-    const inspector = intermediateMessageCatchEvent.inspectorConfig[0].items[0];
+    const inspector = intermediateMessageCatchEvent.inspectorConfig[0].items[1];
     inspector.items[4] = {
         component: 'UserSelect',
         config: {

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -136,7 +136,7 @@
 </template>
 
 <script>
-  import {VueFormBuilder, VueFormRenderer} from "@processmaker/spark-screen-builder";
+  import {VueFormBuilder, VueFormRenderer, FormBuilderControls as controlConfig} from "@processmaker/spark-screen-builder";
   import ComputedProperties from "@processmaker/spark-screen-builder/src/components/computed-properties";
   import CustomCSS from "@processmaker/spark-screen-builder/src/components/custom-css";
   import "@processmaker/spark-screen-builder/dist/vue-form-builder.css";

--- a/resources/js/processes/screen-builder/typeDisplay.js
+++ b/resources/js/processes/screen-builder/typeDisplay.js
@@ -1,7 +1,10 @@
-import {renderer} from "@processmaker/spark-screen-builder";
-import FileDownload from "./components/file-download.vue";
+import FileDownload from "./components/file-download";
 
-const {FormText, FormRecordList, FormMultiColumn} = renderer;
+import {
+    FormMultiColumn,
+    FormText,
+    FormRecordList
+} from "@processmaker/spark-screen-builder";
 
 let initialControls = [{
     builderComponent: FormText,

--- a/resources/js/processes/screen-builder/typeForm.js
+++ b/resources/js/processes/screen-builder/typeForm.js
@@ -3,10 +3,10 @@ import globalProperties from "@processmaker/spark-screen-builder/src/global-prop
 import FileDownload from "./components/file-download";
 import FileUpload from "./components/form/file-upload";
 
-import {renderer} from "@processmaker/spark-screen-builder";
-import {FormBuilderControls as initialControls} from "@processmaker/spark-screen-builder";
-
-const {FormText} = renderer;
+import {
+    FormText,
+} from "@processmaker/spark-screen-builder";
+import initialControls from "@processmaker/spark-screen-builder/src/form-builder-controls";
 
 Vue.component("FileUpload", FileUpload);
 Vue.component("FileDownload", FileDownload);

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -639,6 +639,7 @@
     "The Name of the Lane": "The Name of the Lane",
     "Script Task": "Script Task",
     "The name of the script task": "The name of the script task",
+    "Declare as global": "Declare as global",
     "Sequence Flow": "Sequence Flow",
     "Service Task": "Service Task",
     "Start Event": "Start Event",


### PR DESCRIPTION
Reverts ProcessMaker/spark#1822

@chipit24 @ssshake this did not fix the issue.

[Vue warn]: Invalid Component definition: FormText

found in

---> <VueFormRenderer>
       <ScreenBuilder> at resources/js/processes/screen-builder/screen.vue
         <Root>