### PR TITLE
Remove references of Global Task

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -639,7 +639,6 @@
     "The Name of the Lane": "The Name of the Lane",
     "Script Task": "Script Task",
     "The name of the script task": "The name of the script task",
-    "Declare as global": "Declare as global",
     "Sequence Flow": "Sequence Flow",
     "Service Task": "Service Task",
     "Start Event": "Start Event",


### PR DESCRIPTION
- removed `"Declare as global": "Declare as global",` translations for global tasks

Fixes #1844 