### PR TITLE
Import FormText and others differently

### DIFF
--- a/resources/js/processes/screen-builder/typeDisplay.js
+++ b/resources/js/processes/screen-builder/typeDisplay.js
@@ -1,10 +1,10 @@
 import FileDownload from "./components/file-download";
 
-import {
-    FormMultiColumn,
-    FormText,
-    FormRecordList
-} from "@processmaker/spark-screen-builder";
+import { renderer } from "@processmaker/spark-screen-builder";
+
+let FormText = renderer.FormText;
+let FormRecordList = renderer.FormText;
+let FormMultiColumn = renderer.FormText;
 
 let initialControls = [{
     builderComponent: FormText,


### PR DESCRIPTION
## Changes
- Fixes imports of FormText, FormRecordList, FormMultiColumn in typeDisplay.js similar to the fix previously applied to typeForm.js

Fixes #1847.