### PR TITLE
Adjust inspector width

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -41,7 +41,7 @@
 
         <!-- Preview -->
         <b-row class="h-100" id="preview" v-show="displayPreview">
-          <b-col cols="8" class="overflow-auto h-100 border rounded">
+          <b-col class="overflow-auto h-100 border rounded mr-4">
             <vue-form-renderer ref="renderer"
               v-model="previewData"
               class="p-3 overflow-auto"
@@ -52,36 +52,36 @@
               v-on:css-errors="cssErrors = $event"/>
           </b-col>
 
-          <b-col cols="4" class="overflow-hidden h-100 pr-0 pl-4">
-            <b-card no-body class="p-0">
+          <b-col class="overflow-hidden h-100 preview-inspector p-0">
+            <b-card no-body class="p-0 h-100">
               <b-card-header class="stick-top">
                 {{ $t('Inspector') }}
               </b-card-header>
 
-              <b-card-body class="p-0">
-                <b-button v-b-toggle.dataInput variant="outline"
-                  class="text-left card-header d-flex align-items-center w-100 text-capitalize"
-                  @click="showDataInput = !showDataInput">
-                  <i class="fas fa-file-import mr-2"></i>
-                    {{ $t('Data Input') }}
-                  <i class="fas fa-angle-down ml-auto" :class="{ 'fas fa-angle-right' : !showDataInput }"></i>
-                </b-button>
+              <b-card-body class="p-0 h-100">
+                  <b-button v-b-toggle.dataInput variant="outline"
+                    class="text-left card-header d-flex align-items-center w-100 text-capitalize"
+                    @click="showDataInput = !showDataInput">
+                    <i class="fas fa-file-import mr-2"></i>
+                      {{ $t('Data Input') }}
+                    <i class="fas fa-angle-down ml-auto" :class="{ 'fas fa-angle-right' : !showDataInput }"></i>
+                  </b-button>
 
-                <b-collapse id="dataInput" visible class="overflow-auto">
-                  <form-text-area class="data-height h-100 dataInput"  v-model="previewInput"></form-text-area>
-                </b-collapse>
+                  <b-collapse id="dataInput" visible class="overflow-auto">
+                    <form-text-area class="data-height h-100 dataInput"  v-model="previewInput"></form-text-area>
+                  </b-collapse>
 
-                <b-button v-b-toggle.dataPreview variant="outline"
-                  class="text-left card-header d-flex align-items-center w-100 text-capitalize"
-                  @click="showDataPreview = !showDataPreview">
-                  <i class="fas fa-file-code mr-2"></i>
-                    {{ $t('Data Preview') }}
-                  <i class="fas fa-angle-down ml-auto" :class="{ 'fas fa-angle-right' : !showDataPreview }"></i>
-                </b-button>
+                  <b-button v-b-toggle.dataPreview variant="outline"
+                    class="text-left card-header d-flex align-items-center w-100 text-capitalize"
+                    @click="showDataPreview = !showDataPreview">
+                    <i class="fas fa-file-code mr-2"></i>
+                      {{ $t('Data Preview') }}
+                    <i class="fas fa-angle-down ml-auto" :class="{ 'fas fa-angle-right' : !showDataPreview }"></i>
+                  </b-button>
 
-                <b-collapse id="dataPreview" visible class="mt-2 overflow-auto">
-                  <vue-json-pretty  :data="previewData" class="p-2 data-height"></vue-json-pretty>
-                </b-collapse>
+                  <b-collapse id="dataPreview" visible class="mt-2 overflow-auto">
+                    <vue-json-pretty  :data="previewData" class="p-2 data-height"></vue-json-pretty>
+                  </b-collapse>
               </b-card-body>
             </b-card>
           </b-col>
@@ -383,5 +383,9 @@ import Validator from "validatorjs";
 
     .dataInput {
       margin-top: -25px;
+    }
+
+    .preview-inspector {
+      max-width: 265px;
     }
 </style>


### PR DESCRIPTION
The ticket was reported in spark-builder, but the changes needed to be done in `screen.vue` in spark.

https://github.com/ProcessMaker/spark-screen-builder/issues/172

**Video Demo**
https://drive.google.com/open?id=1PairQgUAOhZTGNTUIotqvsXbY0X-cWIa

<img width="1679" alt="Screen Shot 2019-05-17 at 6 20 06 PM" src="https://user-images.githubusercontent.com/26545455/57959235-ca0ea980-78d0-11e9-8997-2d1a900016e9.png">
