### PR TITLE
Controls installed in packages aren't added to the screen builder

### DIFF
--- a/ProcessMaker/Managers/ScreenBuilderManager.php
+++ b/ProcessMaker/Managers/ScreenBuilderManager.php
@@ -48,8 +48,8 @@ class ScreenBuilderManager
 
         $directories = glob('vendor/processmaker/packages/*', GLOB_ONLYDIR);
         foreach($directories as $directory) {
-            $extensionsFile = $directory . '/js/' . $extensionsFile;
-            $files = glob($extensionsFile);
+            $extensionsFullName = $directory . '/js/' . $extensionsFile;
+            $files = glob($extensionsFullName);
             if (count($files) > 0){
                 $this->addScript('/' . $files[0]);
             }


### PR DESCRIPTION
Resolves #1862 

A variable was concatenating the directory name of every installed package. The variable that was "accumulating" the string has been renamed to work with just one directory at a time.

