### PR TITLE
Preview Inspector uses full height

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -65,30 +65,31 @@
                 {{ $t('Inspector') }}
               </b-card-header>
 
-              <b-card-body class="p-0 h-100">
-                  <b-button v-b-toggle.dataInput variant="outline"
-                    class="text-left card-header d-flex align-items-center w-100 text-capitalize"
-                    @click="showDataInput = !showDataInput">
-                    <i class="fas fa-file-import mr-2"></i>
-                      {{ $t('Data Input') }}
-                    <i class="fas fa-angle-down ml-auto" :class="{ 'fas fa-angle-right' : !showDataInput }"></i>
-                  </b-button>
+              <b-card-body class="p-0 overflow-auto">
+                <b-button variant="outline"
+                  class="text-left card-header d-flex align-items-center w-100 shadow-none text-capitalize"
+                  @click="showDataInput = !showDataInput">
+                  <i class="fas fa-file-import mr-2"></i>
+                    {{ $t('Data Input') }}
+                  <i class="fas ml-auto" :class="showDataInput ? 'fa-angle-right' : 'fa-angle-down'"></i>
+                </b-button>
 
-                  <b-collapse id="dataInput" visible class="overflow-auto">
-                    <form-text-area class="data-height h-100 dataInput"  v-model="previewInput"></form-text-area>
-                  </b-collapse>
+                <b-collapse v-model="showDataInput" id="showDataInput">
+                  <form-text-area class="data-input mb-0 data-collapse" v-model="previewInput"></form-text-area>
+                </b-collapse>
 
-                  <b-button v-b-toggle.dataPreview variant="outline"
-                    class="text-left card-header d-flex align-items-center w-100 text-capitalize"
-                    @click="showDataPreview = !showDataPreview">
-                    <i class="fas fa-file-code mr-2"></i>
-                      {{ $t('Data Preview') }}
-                    <i class="fas fa-angle-down ml-auto" :class="{ 'fas fa-angle-right' : !showDataPreview }"></i>
-                  </b-button>
+                <b-button variant="outline"
+                  class="text-left card-header d-flex align-items-center w-100 shadow-none text-capitalize"
+                  data-toggle="collapse"
+                  @click="showDataPreview = !showDataPreview">
+                  <i class="fas fa-file-code mr-2"></i>
+                    {{ $t('Data Preview') }}
+                  <i class="fas ml-auto" :class="showDataPreview ? 'fa-angle-right' : 'fa-angle-down'"></i>
+                </b-button>
 
-                  <b-collapse id="dataPreview" visible class="mt-2 overflow-auto">
-                    <vue-json-pretty  :data="previewData" class="p-2 data-height"></vue-json-pretty>
-                  </b-collapse>
+                <b-collapse v-model="showDataPreview" id="showDataPreview" class="mt-2">
+                  <vue-json-pretty :data="previewData" class="p-2 data-collapse"></vue-json-pretty>
+                </b-collapse>
               </b-card-body>
             </b-card>
           </b-col>
@@ -183,8 +184,8 @@ import Validator from "validatorjs";
         cssErrors: '',
         showValidationErrors: false,
         toggleValidation: true,
-        showDataPreview: false,
-        showDataInput: false,
+        showDataPreview: true,
+        showDataInput: true,
       };
     },
     components: {
@@ -374,11 +375,19 @@ import Validator from "validatorjs";
       right: 0;
     }
 
-    .dataInput {
+    .data-input {
       margin-top: -25px;
+       textarea.form-control {
+        height: calc(100% - 25px);
+        resize: none;
+      }
     }
 
     .preview-inspector {
       max-width: 265px;
+    }
+
+    .data-collapse {
+      height: 250px;
     }
 </style>


### PR DESCRIPTION
- Preview Inspector height matches the renderer window
<img width="1680" alt="Screen Shot 2019-05-22 at 3 37 31 PM" src="https://user-images.githubusercontent.com/26545455/58203186-8c7e9780-7ca7-11e9-9b8c-460f7b953f95.png">


https://drive.google.com/open?id=1QalQjpvdWeL0P4mQrx_BKGWPPlFW4rAQ