### PR TITLE
Fix issue with sorting

### DIFF
--- a/resources/js/components/common/mixins/datatable.js
+++ b/resources/js/components/common/mixins/datatable.js
@@ -34,7 +34,11 @@ export default {
         },
         // Data manager takes new sorting and calls our fetch method
         dataManager(sortOrder, pagination) {
-            this.orderBy = sortOrder[0].field;
+            if (sortOrder[0].sortField != undefined) {
+              this.orderBy = sortOrder[0].sortField;
+            } else {
+              this.orderBy = sortOrder[0].field;
+            }
             this.orderDirection = sortOrder[0].direction;
             this.fetch();
         },


### PR DESCRIPTION
## Changes
- Sorts vuetables by **sortField** property if that property is set
- Otherwise, sorts by default **field** property

## Notes
- This allows fields to be rendered by slots and still remain sortable

Closes #1880.