### PR TITLE
Set preview display to the form first

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -53,6 +53,7 @@
               v-model="previewData"
               class="p-3 overflow-auto"
               @submit="previewSubmit"
+              :mode="mode"
               :config="config"
               :computed="computed"
               :custom-css="customCSS"


### PR DESCRIPTION
**How to Test**
- Create new form page
- On `default page` (first form) drag a navigation component and set destination to any other page than the default page
- Click Preview, navigate to another page
- Toggle between builder and preview

**Expected**
- Toggling between preview and builder, the first form page will be set as the first one visible 

**Spark Screen Builder**
https://drive.google.com/open?id=1trotZTCBoT3d9_EWiU_5oCTNSuXMO_Bw

Fixes #1881 