### PR TITLE
Don’t trigger leave warning when there are no unsaved changes

### DIFF
--- a/resources/js/leave-warning.js
+++ b/resources/js/leave-warning.js
@@ -1,10 +1,6 @@
 let isTimedOut = false;
 let noUnsavedChanges = true;
 
-console.log('leave-warning created');
-console.log('isTimedOut', isTimedOut);
-console.log('noUnsavedChanges', noUnsavedChanges);
-
 if (window.ProcessMaker) {
     const {AccountTimeoutWorker, EventBus} = window.ProcessMaker;
 

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -293,6 +293,8 @@ import Validator from "validatorjs";
       updateConfig(newConfig) {
         this.config = newConfig
         this.refreshSession();
+        ProcessMaker.EventBus.$emit("new-changes");
+
       },
       updatePreview(data) {
         this.previewData = data
@@ -347,6 +349,7 @@ import Validator from "validatorjs";
                 this.exportScreen();
               }
               ProcessMaker.alert(this.$t("Successfully saved"), "success");
+              ProcessMaker.EventBus.$emit("save-changes");
             });
         }
       }

--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -294,7 +294,6 @@ import Validator from "validatorjs";
         this.config = newConfig
         this.refreshSession();
         ProcessMaker.EventBus.$emit("new-changes");
-
       },
       updatePreview(data) {
         this.previewData = data


### PR DESCRIPTION
Fixes https://github.com/ProcessMaker/spark-screen-builder/issues/209.

**How to test:**
1. Navigate to an existing screen or create a new one.
2. Make some changes and press the save button (ensure it successfully saves).
3. Navigate away from the page (pressing the refresh button is sufficient); you should **not** see the leave page warning.
4. Go back to the screen and make some changes, but this time, **do not** save them!
5. Navigate away from the page; you **should** see the leave page warning now.