### PR TITLE
Add validation to "run script as" when creating a script

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -74,6 +74,14 @@
   // font-size: 14px;
 }
 
+.multiselect.is-invalid .multiselect__tags {
+    border-color: $danger;
+}
+
+.multiselect.is-invalid ~ .invalid-feedback {
+    display: block;
+}
+
 body,
 html {
   width: 100%;

--- a/resources/views/processes/scripts/edit.blade.php
+++ b/resources/views/processes/scripts/edit.blade.php
@@ -32,8 +32,10 @@
                         <multiselect v-model="selectedUser"
                                      label="fullname"
                                      :options="options"
-                                     :searchable="true">
+                                     :searchable="true"
+                                     :class="{'is-invalid': errors.run_as_user_id}">
                         </multiselect>
+                        <div class="invalid-feedback" v-if="errors.run_as_user_id">@{{errors.run_as_user_id[0]}}</div>
                     </div>
                     <div class="form-group">
                         {!! Form::label('description', __('Description')) !!}
@@ -118,9 +120,6 @@
               })
               .catch(error => {
                 if (error.response.status && error.response.status === 422) {
-                  if (error.response.data.errors.run_as_user_id !== undefined) {
-                    ProcessMaker.alert(error.response.data.errors.run_as_user_id[0], 'danger');
-                  }
                   this.errors = error.response.data.errors;
                 }
               });

--- a/resources/views/processes/scripts/index.blade.php
+++ b/resources/views/processes/scripts/index.blade.php
@@ -80,8 +80,9 @@
                         <div class="form-group">
                             <label class="typo__label">{{__('Run script as')}}</label>
                             <multiselect v-model="selectedUser" label="fullname" :options="users" :placeholder="$t('Select')"
-                                         :searchable="true"></multiselect>
-                        <small class="form-text text-muted">{{__('Select a user to set the API access of the Script')}}</small>
+                                         :searchable="true" :class="{'is-invalid': addError.run_as_user_id}"></multiselect>
+                            <small class="form-text text-muted" v-if="! addError.run_as_user_id">{{__('Select a user to set the API access of the Script')}}</small>
+                            <div class="invalid-feedback" v-for="run_as_user_id in addError.run_as_user_id">@{{run_as_user_id}}</div>
                         </div>
 
                         <div class="form-group">

--- a/resources/views/processes/scripts/index.blade.php
+++ b/resources/views/processes/scripts/index.blade.php
@@ -166,9 +166,6 @@
                   .catch(error => {
                     this.disabled = false;
                     if (error.response.status && error.response.status === 422) {
-                      if (error.response.data.errors.run_as_user_id !== undefined) {
-                        ProcessMaker.alert(error.response.data.errors.run_as_user_id[0], 'danger');
-                      }
                       this.addError = error.response.data.errors;
                     }
                   })


### PR DESCRIPTION
## Changes
- Adds global classes to allow multiselect validation to appear
- Adds standard validation to "run script as" field when creating and configuring scripts

## Notes
- Now that the global classes exist, we may want to look for any other areas in the app where multiselects need standard validation

## Screenshots
![Screen Shot 2019-05-28 at 11 45 19 AM](https://user-images.githubusercontent.com/867714/58504092-bcfa8180-813e-11e9-940b-e25194b8c08b.png)
![Screen Shot 2019-05-28 at 11 45 29 AM](https://user-images.githubusercontent.com/867714/58504093-bcfa8180-813e-11e9-8a55-7e0f8aa7cd53.png)

Fixes #1740.