### PR TITLE
Fixing issue with stylesheet loading in minimal layout

### DIFF
--- a/resources/views/layouts/minimal.blade.php
+++ b/resources/views/layouts/minimal.blade.php
@@ -7,7 +7,7 @@
     <link rel="shortcut icon" type="image/x-icon" href="https://pbs.twimg.com/profile_images/521685439820742657/8B2oQKmP_400x400.jpeg" />
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>@yield('title',__('Welcome')) - ProcessMaker Spark</title>
-    <link href="{{ asset('css/app.css') }}" rel="stylesheet">
+    <link href="{{ mix('css/app.css') }}" rel="stylesheet">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon.png">
 @yield('css')
 </head>


### PR DESCRIPTION
## Changes
- Changes the minimal layout to load app.css using the mix helper rather than the asset helper

## Notes
- This issue appeared when a production instance deployed and app.css was being incorrectly served via HTTP instead of HTTPS. It also did not have the cache busting string attached to it.

Fixes #1947.