### PR TITLE
Fix text color picker on screen builder

### DIFF
--- a/resources/js/processes/screen-builder/screen.vue
+++ b/resources/js/processes/screen-builder/screen.vue
@@ -35,7 +35,7 @@
       </b-card-header>
 
       <!-- Card Body -->
-      <b-card-body class="overflow-auto ml-3 mr-3">
+      <b-card-body class="overflow-auto ml-3 mr-3" id="screen-builder-container">
         <!-- Vue-form-builder -->
         <vue-form-builder
           :validationErrors="validationErrors"

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -180,13 +180,10 @@ html {
 }
 
 .form-group label {
-  color: #788793;
   margin-bottom: 4px;
 }
 
 .form-check label {
-  // font-size: 14px;
-  color: #788793;
   margin-bottom: 0;
 }
 


### PR DESCRIPTION
PR(https://github.com/ProcessMaker/spark-screen-builder/pull/229) from Screen Builder Repo needs to be merged for fixes to be applied.

- Remove the css color overwrite on form group/checkbox labels because these rules were overwriting the bootstrap classes attached when selecting a text color.
- Fix custom css bug

**Spark Video Demo - Text Color Fix**
https://drive.google.com/open?id=15tSnFtkOju6pN3BPFcfiBIJ3nFjiyl-2

**Spark Video Demo - Custom Css Fix**
https://drive.google.com/open?id=1nZPsd_oxCWNzdVkfGUqM88qcY8O80tLo

Fixes #1954 