### PR TITLE
Fix show log layout

### DIFF
--- a/resources/views/requests/show.blade.php
+++ b/resources/views/requests/show.blade.php
@@ -80,7 +80,7 @@
                              role="tabpanel" aria-labelledby="summary-tab">
                             <template v-if="showSummary">
                                 <template v-if="showScreenSummary">
-                                    <div class="card m-3">
+                                    <div class="card">
                                         <div class="card-body">
                                             <task-screen ref="screen" :screen="screenSummary" :data="dataSummary"/>
                                         </div>


### PR DESCRIPTION
Resolves #1966 

This PR resolves the margin in the request log.

- Fixed the margin when the process has a end event display screen:

![image](https://user-images.githubusercontent.com/8028650/59357114-39bd5c00-8cf8-11e9-9f9d-32a46804df76.png)
